### PR TITLE
fix: truncate file when untar

### DIFF
--- a/fsutil/tar.go
+++ b/fsutil/tar.go
@@ -125,17 +125,23 @@ func untar(reader io.Reader, dst string) error {
 				return err
 			}
 		case tar.TypeReg: // file
-			file, err := os.OpenFile(dstPath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
+			if err = createf(tr, dstPath, header.FileInfo().Mode()); err != nil {
 				return err
 			}
-			_, err = io.Copy(file, tr)
-			if err != nil {
-				_ = file.Close()
-				return err
-			}
-			_ = file.Close()
 		}
+	}
+	return nil
+}
+
+func createf(src io.Reader, dst string, mode os.FileMode) error {
+	file, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	_, err = io.Copy(file, src)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/fsutil/tar_test.go
+++ b/fsutil/tar_test.go
@@ -19,6 +19,22 @@ func TestTar(t *testing.T) {
 	defer func() { _ = os.RemoveAll(undst) }()
 	err = UnTar(unsrc, undst)
 	assert.NoError(t, err)
+
+	f, err := os.Stat("testdata/src2/testdata/src/subdir")
+	assert.NoError(t, err)
+	assert.True(t, f.IsDir())
+
+	f, err = os.Stat("testdata/src2/testdata/src/a.txt")
+	assert.NoError(t, err)
+	assert.False(t, f.IsDir())
+
+	f, err = os.Stat("testdata/src2/testdata/src/b.txt")
+	assert.NoError(t, err)
+	assert.False(t, f.IsDir())
+
+	f, err = os.Stat("testdata/src2/testdata/src/subdir/c.txt")
+	assert.NoError(t, err)
+	assert.False(t, f.IsDir())
 }
 
 func TestTarFile(t *testing.T) {
@@ -33,6 +49,13 @@ func TestTarFile(t *testing.T) {
 	defer func() { _ = os.RemoveAll(undst) }()
 	err = UnTar(unsrc, undst)
 	assert.NoError(t, err)
+	f, err := os.Stat("testdata/src2/testdata/src/subdir")
+	assert.NoError(t, err)
+	assert.True(t, f.IsDir())
+
+	f, err = os.Stat("testdata/src2/testdata/src/subdir/c.txt")
+	assert.NoError(t, err)
+	assert.False(t, f.IsDir())
 }
 
 func TestCompress(t *testing.T) {


### PR DESCRIPTION
Thank you for contributing to golib!

# Please add a summary of your change

fix: truncate file when untar

# Does your change fix a particular issue?

Fixes #(issue)

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.